### PR TITLE
Eliminate static data when unreferenced

### DIFF
--- a/SpwfSAInterface.cpp
+++ b/SpwfSAInterface.cpp
@@ -38,19 +38,7 @@
 #include "BlockExecuter.h"
 
 #if MBED_CONF_RTOS_PRESENT
-static Mutex _spwf_mutex; // assuming a recursive mutex
-static void _spwf_lock() {
-    (void)(_spwf_mutex.lock());
-}
-static Callback<void()> _callback_spwf_lock(&_spwf_lock);
-
-static void _spwf_unlock() {
-    (void)(_spwf_mutex.unlock());
-}
-static Callback<void()> _callback_spwf_unlock(&_spwf_unlock);
-
-#define SYNC_HANDLER \
-        BlockExecuter sync_handler(_callback_spwf_unlock, _callback_spwf_lock)
+#define SYNC_HANDLER ScopedMutexLock sync_handler(_spwf_mutex)  // assuming a recursive mutex
 #else
 #define SYNC_HANDLER
 #endif

--- a/SpwfSAInterface.h
+++ b/SpwfSAInterface.h
@@ -385,6 +385,10 @@ private:
     } _cbs[SPWFSA_SOCKET_COUNT];
     int _internal_ids[SPWFSA_SOCKET_COUNT];
 
+#if MBED_CONF_RTOS_PRESENT
+    Mutex _spwf_mutex;
+#endif
+
     char ap_ssid[33]; /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
     nsapi_security_t ap_sec;
     char ap_pass[64]; /* The longest allowed passphrase */


### PR DESCRIPTION
Avoid static ROM + RAM use when driver is not referenced.

Saves about 150 bytes of ROM and 50 bytes of RAM in mbed OS
easy-connect when using a different driver.

Switches mutex locking from built-in BlockExecuter to the
ScopedMutexLock from mbed OS.