### PR TITLE
Allow IDW01xx to provide default WifiInterface

### DIFF
--- a/SpwfSAInterface.cpp
+++ b/SpwfSAInterface.cpp
@@ -498,3 +498,12 @@ nsapi_size_or_error_t SpwfSAInterface::scan(WiFiAccessPoint *res, unsigned count
 
     return ret;
 }
+
+#if MBED_CONF_IDW0XX1_PROVIDE_DEFAULT
+
+WiFiInterface *WiFiInterface::get_default_instance() {
+    static SpwfSAInterface spwf(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
+    return &spwf;
+}
+
+#endif

--- a/SpwfSAInterface.cpp
+++ b/SpwfSAInterface.cpp
@@ -502,7 +502,7 @@ nsapi_size_or_error_t SpwfSAInterface::scan(WiFiAccessPoint *res, unsigned count
 #if MBED_CONF_IDW0XX1_PROVIDE_DEFAULT
 
 WiFiInterface *WiFiInterface::get_default_instance() {
-    static SpwfSAInterface spwf(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
+    static SpwfSAInterface spwf(MBED_CONF_IDW0XX1_TX, MBED_CONF_IDW0XX1_RX);
     return &spwf;
 }
 

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -12,6 +12,10 @@
         "rx":{
             "help": "RX pin for serial connection to external device",
             "value": "NC"
+        },
+        "provide-default": {
+            "help": "Provide default WifiInterface. [true/false]",
+            "value": false
         }
     }
 }


### PR DESCRIPTION
SpwfSAinterface can provide default WifiInterface for Mbed OS by setting
"idw0xx1.provide-default": true in mbed_app.json